### PR TITLE
Added Common.Layout.ps1 script and updated List-VMsInDomain function

### DIFF
--- a/vmbuild/Common.ps1
+++ b/vmbuild/Common.ps1
@@ -4263,6 +4263,7 @@ Function Set-TitleBar {
 . $PSScriptRoot\common\Common.Maintenance.ps1
 . $PSScriptRoot\common\Common.ScriptBlocks.ps1
 . $PSScriptRoot\common\Common.GenConfig.ps1
+. $PSScriptRoot\common\Common.Layout.ps1
 . $PSScriptRoot\common\Common.HyperV.ps1
 . $PSScriptRoot\common\Common.snapshots.ps1
 . $PSScriptRoot\common\Common.menu.ps1

--- a/vmbuild/common/Common.Layout.ps1
+++ b/vmbuild/common/Common.Layout.ps1
@@ -7,6 +7,10 @@ Function Get-LabVMs{
     )
 
     $vms = Get-List -Type VM -domain $DomainName
+    if ($LineCount) {
+        return $vms.count + 2
+    }
+
     if ($vms) {
         
         # Define colors for state and role

--- a/vmbuild/common/Common.Layout.ps1
+++ b/vmbuild/common/Common.Layout.ps1
@@ -1,5 +1,7 @@
 Function Get-LabVMs{
     param (
+        [Parameter(Mandatory = $false)]
+        [switch] $LineCount,
         [Parameter(Mandatory = $false, HelpMessage = "Domain Name")]
         [string] $DomainName
     )

--- a/vmbuild/common/Common.Layout.ps1
+++ b/vmbuild/common/Common.Layout.ps1
@@ -1,0 +1,88 @@
+Function Get-LabVMs{
+    param (
+        [Parameter(Mandatory = $false, HelpMessage = "Domain Name")]
+        [string] $DomainName
+    )
+
+    $vms = Get-List -Type VM -domain $DomainName
+    if ($vms) {
+        
+        # Define colors for state and role
+        $stateColor = @{ "Running" = "Green"; "Off" = "Red" }
+        $roleColor = @{ "CAS" = "Yellow"; "Primary" = "Yellow"; "DC" = "White"; "SiteSystem" = "Yellow"; "DomainMember" = "Cyan" }
+
+        # Extract properties and headers
+        $properties = @("VmName", "Domain", "State", "Role", "SiteCode", "DeployedOS", "MemoryStartupGB", "DiskUsedGB", "SqlVersion", "LastKnownIP")
+        $headers = @("VM Name", "Domain", "State", "Role", "Site", "Deployed OS", "Memory", "Disk Used", "SQL Version", "Last Known IP")
+
+        # Calculate max width for each column (across ALL VMs for consistency)
+        $columnWidths = foreach ($i in 0..($headers.Length - 1)) {
+            $headerLength = $headers[$i].Length
+            $maxDataLength = ($vms | ForEach-Object { 
+                    $value = $_.($properties[$i])
+                    if ($i -in 6, 7) { "$value GB" } else { "$value" } 
+                } | Measure-Object -Property Length -Maximum).Maximum
+            
+            [Math]::Max($headerLength, $maxDataLength) + 1  # Add padding
+        }
+
+        # Group VMs by Domain
+        $groups = $vms | Sort-Object -Property Domain, VmName | Group-Object -Property Domain
+
+        # Display tables per domain
+        foreach ($group in $groups) {
+            $domainVMs = $group.Group
+
+            # Print header for the domain
+            for ($i = 0; $i -lt $headers.Length; $i++) {
+                $width = $columnWidths[$i]  # $columnWidths is an array of columns' width
+                Write-Host ("{0,-$width}" -f $headers[$i]) -NoNewline -ForegroundColor White -BackgroundColor DarkBlue
+            }
+            Write-Host ""
+
+            # Print rows for the domain
+            foreach ($vm in $domainVMs) {
+                $rowData = @(
+                    $vm.VmName,
+                    $vm.Domain,
+                    $vm.State,
+                    $vm.Role,
+                    $vm.SiteCode,
+                    $vm.DeployedOS,
+                    "$($vm.MemoryStartupGB) GB",
+                    "$([Math]::Round($vm.DiskUsedGB, 2)) GB",
+                    $vm.SqlVersion,
+                    $vm.LastKnownIP
+                )
+
+                for ($i = 0; $i -lt $headers.Length; $i++) {
+                    $value = $rowData[$i]
+                    $width = $columnWidths[$i]
+                    $formatString = "{0,-$width}"
+
+                    # Apply color logic
+                    if ($i -eq 2) {
+                        $StateString = $value
+                        If ($StateString -eq "Running") {$stateString= "On"}
+                        # State column
+                        Write-Host ($formatString -f $value) -NoNewline -ForegroundColor $stateColor[$value]
+                    }
+                    elseif ($i -eq 3) {
+                        # Role column
+                        Write-Host ($formatString -f $value) -NoNewline -ForegroundColor $roleColor[$value]
+                    }
+                    else {
+                        Write-Host ($formatString -f $value) -NoNewline
+                    }
+                }
+                Write-Host ""  # Newline
+            }
+
+            # Add whitespace between tables
+            Write-Host "`n"
+        }
+    }
+    else {
+        Write-Host "No VMs found." -ForegroundColor Red
+    }
+}

--- a/vmbuild/genconfig.ps1
+++ b/vmbuild/genconfig.ps1
@@ -492,9 +492,7 @@ function Select-VMMenu {
 
     Write-Verbose "2 Select-VMMenu"
     while ($true) {
-       
-       
-        $customOptions = [ordered]@{"*F" = "Show-VMS" }
+        $customOptions = [ordered]@{"*F" = "Get-LabVMs" }
         $response = Get-Menu2 -MenuName "Currently Deployed VMs" -Prompt "Press Enter" -AdditionalOptions $customOptions -HideHelp:$true -test:$false
 
         write-Verbose "1 response $response"
@@ -519,7 +517,8 @@ function List-VMsInDomain {
     if (-not $vmsInDomain) {
         return
     }
-    ($vmsInDomain | Select-Object VmName, State, Role, SiteCode, DeployedOS, @{E = { "$($_.DynamicMinRam)-$($_.Memory)" }; L = "Memory" }, DiskUsedGB, SqlVersion | Format-Table | Out-String).Trim() | out-host
+    # ($vmsInDomain | Select-Object VmName, State, Role, SiteCode, DeployedOS, @{E = { "$($_.DynamicMinRam)-$($_.Memory)" }; L = "Memory" }, DiskUsedGB, SqlVersion | Format-Table | Out-String).Trim() | out-host
+    Get-LabVMs -domain $DomainName
 }
 function Select-DomainMenu {
     param (


### PR DESCRIPTION
1st Change: Added Common.Layout.ps1 script and updated List-VMsInDomain function

- Added $PSScriptRoot\common\Common.Layout.ps1 file.
- Updated custom options in the script: Changed "*F" value from "Show-VMS" to "Get-LabVMs".
- Refactored List-VMsInDomain function to use "Get-LabVMs -domain $DomainName" instead of commented-out code for listing VMs.

2nd Change: Added optional [switch] $LineCount parameter to Get-LabVMs to resolve invocation error

- Introduced a [switch] $LineCount parameter in the Get-LabVMs function.
- The parameter is optional and non-mandatory, allowing flexibility in function calls.
- This change resolves the error encountered in function New-MenuItem, where invoking `$function -LineCount` caused the issue: "A parameter cannot be found that matches parameter name 'LineCount'."

